### PR TITLE
Add ThingPulse Pendrive S3

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -520,3 +520,6 @@ PID    | Product name
 0x8200 | Unexpected Maker RGBTouch Mini - UF2 Bootloader
 0x8201 | UMD - Logger
 0x8203 | EMC - EMCFFB
+0x8204 | ThingPulse Pendrive S3 128MB - Arduino
+0x8205 | ThingPulse Pendrive S3 128MB - Circuit Python
+0x8206 | ThingPulse Pendrive S3 128MB - UF2 Bootloader

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -519,7 +519,7 @@ PID    | Product name
 0x81FF | Unexpected Maker RGBTouch Mini - CircuitPython
 0x8200 | Unexpected Maker RGBTouch Mini - UF2 Bootloader
 0x8201 | UMD - Logger
+0x8202 | ThingPulse Pendrive S3 128MB - Arduino
 0x8203 | EMC - EMCFFB
-0x8204 | ThingPulse Pendrive S3 128MB - Arduino
-0x8205 | ThingPulse Pendrive S3 128MB - Circuit Python
-0x8206 | ThingPulse Pendrive S3 128MB - UF2 Bootloader
+0x8204 | ThingPulse Pendrive S3 128MB - Circuit Python
+0x8205 | ThingPulse Pendrive S3 128MB - UF2 Bootloader


### PR DESCRIPTION
- Device description: USB stick for automation and pentesting
- Chip: ESP32-S3-Mini-1
- Reason for PID: required by CircuitPython
- Company: ThingPulse
- URL with more information: https://thingpulse.com/product/esp32-s3-pendrive-s3-128mb/

Kind regards, 
Daniel